### PR TITLE
Install python3 as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Runtimes:
 
 * `golang 1.17.x`
 * `openjdk 11`
+* `python 3.9`
 
 Libraries:
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             pkgs.kubernetes-helm
             pkgs.nodejs
             pkgs.openshift
+            pkgs.python3
             pkgs.wget
             pkgs.yarn
             pkgs.yq-go


### PR DESCRIPTION
The Python 3.6 in RHEL is too old to support the version of `setuptools` required by stackrox operator bundle helper scripts.