### PR TITLE
Bump go to 1.18.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Isolated and reproducible development environment for the Stackrox stack using N
 
 Compilers / runtimes:
 
-* `golang 1.17.x`
+* `golang 1.18.x`
 * `openjdk 11`
 * `python 3.9`
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
             pkgs.gcc
             pkgs.gettext # Needed for `envsubst`
             pkgs.gnumake
-            pkgs.go_1_17
+            pkgs.go_1_18
             pkgs.google-cloud-sdk
             pkgs.gradle
             pkgs.jdk11


### PR DESCRIPTION
Tested by running `make -C operator test`.