### PR TITLE
ROX-13649: Add fleet-manager tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Compilers / runtimes:
 
 * `golang 1.18.x`
 * `openjdk 11`
-* `python 3.9`
+* `python 3.10`
 
 Libraries:
 
@@ -18,8 +18,10 @@ Libraries:
 
 Applications:
 
+* `aws` and `aws-vault`
 * `bats`
 * Repo cleaner `bfg`
+* `chamber`
 * `colima` (macOS)
 * `docker` (macOS)
 * `gcc`

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656964352,
-        "narHash": "sha256-pA4cdXMkXt/2PEkSQFz2RvOAhqSccYcU9WMtCM6h+7Y=",
+        "lastModified": 1670903062,
+        "narHash": "sha256-6Ck/gurgLLu5AwH6rekBmwydTjr4QLDCgz9HX10df/o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "95cc37ab9a2b9d402a2f6df83d520e7dd19c5f4d",
+        "rev": "4096ed383d3e7b8aa54228bd47f47a66e5c439da",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
           else [ ];
         # Add Python packages here.
         python-packages = ps: [
+          ps.python-ldap # Dependency of aws-saml.py
           ps.pyyaml
         ];
         stackrox-python = pkgs.python3.withPackages python-packages;
@@ -27,27 +28,38 @@
       {
         devShell = pkgs.mkShell {
           buildInputs = [
+            # stackrox/stackrox
             pkgs-rocksdb.rocksdb
             pkgs.bats
-            pkgs.bfg-repo-cleaner
-            pkgs.cachix
-            pkgs.gcc
             pkgs.gettext # Needed for `envsubst`
-            pkgs.gnumake
-            pkgs.go_1_18
             pkgs.google-cloud-sdk
             pkgs.gradle
             pkgs.jdk11
+            pkgs.nodejs
+            pkgs.yarn
+
+            # stackrox/acs-fleet-manager
+            pkgs.aws-vault
+            pkgs.awscli2
+            pkgs.chamber
+            pkgs.krb5 # Dependency of aws-saml.py
+            pkgs.pre-commit
+
+            # openshift
+            pkgs.ocm
+            pkgs.openshift
+
+            # misc
+            pkgs.bfg-repo-cleaner
+            pkgs.cachix
+            pkgs.gcc
+            pkgs.gnumake
+            pkgs.go_1_18
             pkgs.jq
             pkgs.kubectl
             pkgs.kubectx
             pkgs.kubernetes-helm
-            pkgs.nodejs
-            pkgs.ocm
-            pkgs.openshift
-            pkgs.pre-commit
             pkgs.wget
-            pkgs.yarn
             pkgs.yq-go
             stackrox-python
           ] ++ darwin-pkgs;


### PR DESCRIPTION
Add some AWS tooling for the fleet-manager repo. I'm not sure `aws-saml.py` works as expected with this. But at least it compiles for me with `make /Users/stephan/go/src/github.com/stackrox/acs-fleet-manager/bin/tools_venv`.

However upon executing the terraform script I'm getting
```
Getting a Kerberos ticket
kinit: Client 'stephan@IPA.REDHAT.COM' not found in Kerberos database while getting initial credentials
```