### PR TITLE
add binary cache to speed up pulling new envs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,17 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Check out repository
-      uses: actions/checkout@v2.4.0
+      - name: Check out repository
+        uses: actions/checkout@v2.4.0
 
-    - name: Install Nix
-      uses: cachix/install-nix-action@v16
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
 
-    - name: Build dev environment
-      run: nix develop
+      - name: Setup binary cache
+        uses: cachix/cachix-action@v12
+        with:
+          name: stackrox
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build dev environment
+        run: nix develop

--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ Deploy a local Kubernetes cluster with access to images built or pulled with `do
 colima start --with-kubernetes
 ```
 
+## Binary cache
+
+To avoid long build times, all packages can be pulled from a binary cache. The `build` GitHub action builds
+all packages and pushes them to the binary cache `stackrox.cachix.org`. Using the binary cache is optional.
+See this [guide](https://nix.dev/faq#how-do-i-add-a-new-binary-cache) on how to enable the cache.
+
+```
+trusted-substituter: https://stackrox.cachix.org
+trusted-public-key: stackrox.cachix.org-1:Wnn8TKAitOTWKfTvvHiHzJjXy0YfiwoK6rrVzXt/trA=
+```
+
+Alternativley, run
+
+```sh
+cachix use stackrox
+```
+
+which modifies the Nix system config as described above.
+
 ## Caveats
 
 Loading the development environment inserts the `Nix` binaries at the beginning of `$PATH`.

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             pkgs-rocksdb.rocksdb
             pkgs.bats
             pkgs.bfg-repo-cleaner
+            pkgs.cachix
             pkgs.gcc
             pkgs.gettext # Needed for `envsubst`
             pkgs.gnumake


### PR DESCRIPTION
I haven't tested out the binary cache feature yet, but it should speed things by avoiding builds on developer machines. Instead, packages are built by the GitHub action and pushed to the cache.

For the push to work, we need to add the push secret `secrets.CACHIX_AUTH_TOKEN`.