### PR TITLE
update nix action to v20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v19
+        uses: cachix/install-nix-action@v20
 
       - name: Setup binary cache
         uses: cachix/cachix-action@v12


### PR DESCRIPTION
fix nix actions due to recent bug. See https://github.com/cachix/install-nix-action/issues/161.