### PR TITLE
pin nixpkgs to unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,15 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683526594,
-        "narHash": "sha256-HYpnC6W6hz9zQvzZohdeS8PMJaNbkBmW7WWq/Km4qPk=",
+        "lastModified": 1684242266,
+        "narHash": "sha256-uaCQ2k1bmojHKjWQngvnnnxQJMY8zi1zq527HdWgQf8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8fb30e1471ed7c83f9e1a59c5b6c3c973cb885b1",
+        "rev": "7e0743a5aea1dc755d4b761daf75b20aa486fdad",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nixpkgs-rocksdb-6_15_5.url = "github:nixos/nixpkgs/a765beccb52f30a30fee313fbae483693ffe200d";
     flake-utils.url = "github:numtide/flake-utils";
   };


### PR DESCRIPTION
Pin nixpkgs to unstable instead of HEAD. This should reduce the number of packages that are not yet available in binary caches when we do a `nix flake update`.