### PR TITLE
chore: update deps; pin hashicorp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         uses: cachix/install-nix-action@v25
         with:
           extra_nix_config: |
+            accept-flake-config = true
             auto-optimise-store = true
 
       - name: Setup binary cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,24 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Free disk space
+        # https://github.com/actions/virtual-environments/issues/709
+        run: |
+          echo "========= Original CI disk space"
+          df -h
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          echo "========= After clean up CI disk space"
+          df -h
+
       - name: Check out repository
         uses: actions/checkout@v4.1.1
 
       - name: Install Nix
         uses: cachix/install-nix-action@v25
+        with:
+          extra_nix_config: |
+            auto-optimise-store = true
 
       - name: Setup binary cache
         uses: cachix/cachix-action@v14

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Applications:
 * OpenShift Cluster Manager Client `ocm`
 * `pre-commit`
 * `prometheus`
-* `terraform` and `terragrunt`
-* `vault`
+* `terraform 1.5.7` (last MPL release) and `terragrunt`
+* `vault 1.14.8` (last MPL release)
 * `wget`
 * `yarn`
 * `yq`

--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,33 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -20,16 +38,34 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684242266,
-        "narHash": "sha256-uaCQ2k1bmojHKjWQngvnnnxQJMY8zi1zq527HdWgQf8=",
+        "lastModified": 1709386671,
+        "narHash": "sha256-VPqfBnIJ+cfa78pd4Y5Cr6sOWVW8GYHRVucxJGmRf8Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7e0743a5aea1dc755d4b761daf75b20aa486fdad",
+        "rev": "fa9a51752f1b5de583ad5213eb621be071806663",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -50,14 +86,83 @@
         "type": "github"
       }
     },
+    "nixpkgs-terraform": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1709212517,
+        "narHash": "sha256-xPRdK5TlilYmSpfucvUl8CRDB2gXqqMjDJU9ZSNt62I=",
+        "owner": "stackbuilders",
+        "repo": "nixpkgs-terraform",
+        "rev": "da278f71a9e2fbc9080ddedf8d7332ba9504dbf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stackbuilders",
+        "repo": "nixpkgs-terraform",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1704008649,
+        "narHash": "sha256-rGPSWjXTXTurQN9beuHdyJhB8O761w1Zc5BqSSmHvoM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d44d59d2b5bd694cd9d996fd8c51d03e3e9ba7f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1699291058,
+        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-rocksdb-6_15_5": "nixpkgs-rocksdb-6_15_5"
+        "nixpkgs-rocksdb-6_15_5": "nixpkgs-rocksdb-6_15_5",
+        "nixpkgs-terraform": "nixpkgs-terraform"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -6,25 +6,30 @@
       "https://stackrox.cachix.org"
       "https://cache.nixos.org"
       "https://nix-community.cachix.org"
+      "https://nixpkgs-terraform.cachix.org"
     ];
     trusted-public-keys = [
       "stackrox.cachix.org-1:Wnn8TKAitOTWKfTvvHiHzJjXy0YfiwoK6rrVzXt/trA="
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "nixpkgs-terraform.cachix.org-1:8Sit092rIdAVENA3ZVeH9hzSiqI/jng6JiCrQ1Dmusw="
     ];
   };
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nixpkgs-rocksdb-6_15_5.url = "github:nixos/nixpkgs/a765beccb52f30a30fee313fbae483693ffe200d";
+    nixpkgs-terraform.url = "github:stackbuilders/nixpkgs-terraform";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-rocksdb-6_15_5, flake-utils }:
+  outputs = { self, nixpkgs, nixpkgs-rocksdb-6_15_5, nixpkgs-terraform, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
+        custom = import ./pkgs { inherit pkgs; };
         pkgs-rocksdb = import nixpkgs-rocksdb-6_15_5 { inherit system; };
+        terraform = nixpkgs-terraform.packages.${system}."1.5.7";
         darwin-pkgs =
           if pkgs.stdenv.isDarwin then [
             pkgs.colima
@@ -61,7 +66,7 @@
             pkgs.pre-commit
 
             # stackrox/acs-fleet-manager-aws-config
-            pkgs.terraform
+            terraform
             pkgs.terragrunt
             pkgs.detect-secrets
 
@@ -84,7 +89,7 @@
             pkgs.kubectx
             pkgs.kubernetes-helm
             pkgs.prometheus
-            pkgs.vault
+            custom.vault
             pkgs.wget
             pkgs.yq-go
             stackrox-python

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,0 +1,3 @@
+{ pkgs }: {
+  vault = pkgs.callPackage ./vault { };
+}

--- a/pkgs/vault/default.nix
+++ b/pkgs/vault/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildGoModule
+, installShellFiles
+, nixosTests
+, makeWrapper
+, gawk
+, glibc
+}:
+buildGoModule rec {
+  pname = "vault";
+  version = "1.14.8";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = "vault";
+    rev = "v${version}";
+    sha256 = "sha256-sGCODCBgsxyr96zu9ntPmMM/gHVBBO+oo5+XsdbCK4E=";
+  };
+
+  vendorHash = "sha256-zpHjZjgCgf4b2FAJQ22eVgq0YGoVvxGYJ3h/3ZRiyrQ=";
+
+  proxyVendor = true;
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  tags = [ "vault" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/hashicorp/vault/sdk/version.GitCommit=${src.rev}"
+    "-X github.com/hashicorp/vault/sdk/version.Version=${version}"
+    "-X github.com/hashicorp/vault/sdk/version.VersionPrerelease="
+  ];
+
+  postInstall =
+    ''
+      echo "complete -C $out/bin/vault vault" > vault.bash
+      installShellCompletion vault.bash
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      wrapProgram $out/bin/vault \
+        --prefix PATH ${lib.makeBinPath [gawk glibc]}
+    '';
+
+  passthru.tests = { inherit (nixosTests) vault vault-postgresql vault-dev vault-agent; };
+
+  meta = with lib; {
+    homepage = "https://www.vaultproject.io/";
+    description = "A tool for managing secrets";
+    changelog = "https://github.com/hashicorp/vault/blob/v${version}/CHANGELOG.md";
+    license = licenses.mpl20;
+    mainProgram = "vault";
+    maintainers = with maintainers; [ rushmorem lnl7 offline pradeepchhetri Chili-Man techknowlogick ];
+  };
+}


### PR DESCRIPTION
Update our dependencies. Since HashiCorp changed the licences for `terraform` and `vault` to from mpl to bsl, there are concerns about usage legality. Personally I don't think we need to worry as bsl targets reseller (i.e. embedding HashiCorp products AND competing with HashiCorp), which we are not. Nonetheless, this pins `terraform`/`vault` to the last mpl based versions for now.

The vault derivation is taken from `nixpkgs`.