### PR TITLE
chore: update flake revision

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709386671,
-        "narHash": "sha256-VPqfBnIJ+cfa78pd4Y5Cr6sOWVW8GYHRVucxJGmRf8Q=",
+        "lastModified": 1710066242,
+        "narHash": "sha256-bO7kahLdawW7rBqUTfWgf9mdPYrnOo5DGvWRJa9N8Do=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fa9a51752f1b5de583ad5213eb621be071806663",
+        "rev": "db339f1706f555794b71aa4eb26a5a240fb6a599",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1709212517,
-        "narHash": "sha256-xPRdK5TlilYmSpfucvUl8CRDB2gXqqMjDJU9ZSNt62I=",
+        "lastModified": 1709829919,
+        "narHash": "sha256-DhdTWzTjrRubxGzKzehyrPrsQaFM1li3AOmZDiLLdqc=",
         "owner": "stackbuilders",
         "repo": "nixpkgs-terraform",
-        "rev": "da278f71a9e2fbc9080ddedf8d7332ba9504dbf8",
+        "rev": "d316e03581f4807d89edd187558b22f8dde8f992",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update flake revision. Should now include the latest `k9s` version https://github.com/NixOS/nixpkgs/commit/672b0cdb2fa8f3b65093ef5aade4c61f067a4905.