### PR TITLE
Bump go, install docker-buildx and goreleaser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Isolated and reproducible development environment for the Stackrox stack using N
 Compilers / runtimes:
 
 * `gcc`
-* `golang 1.21.x`
+* `golang 1.22.x`
 * `openjdk 11`
 * `python 3.10`
 
@@ -28,9 +28,11 @@ Applications:
 * `colima` (macOS)
 * `detect-secrets`
 * `docker` (macOS)
+* `docker-buildx`
 * `envsubst` (and other gettext utilities)
 * `gcloud`
 * `go-jsonnet` and bundler
+* `goreleaser`
 * `gradle`
 * `helm`
 * `jq`

--- a/flake.nix
+++ b/flake.nix
@@ -110,8 +110,10 @@
                 bfg-repo-cleaner
                 bitwarden-cli
                 cachix
+                docker-buildx
                 gcc
                 gnumake
+                goreleaser
                 jq
                 jsonnet-bundler
                 k9s
@@ -121,7 +123,7 @@
                 prometheus
                 wget
                 ;
-              go = pkgs.go_1_21;
+              go = pkgs.go_1_22;
               helm = pkgs.kubernetes-helm;
               jsonnet = pkgs.go-jsonnet;
               python = pkgs.python3.withPackages python-pkgs;


### PR DESCRIPTION
I'm doing a `nix flake update` in the background to bump to 1.22.5, but let's merge this first for easier rollback if need be.