### PR TITLE
bump golang version to 1.22.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,13 @@ To install the pre-commit hook, run `pre-commit install` from within the reposit
 If you're getting error such as `error: attribute 'whatever_new_version'
 missing` after bumping to a new version of a package, try running `nix flake
 update`.
+
+### Updating isolated packages
+
+To only update an isolated package - for example, to bump the golang version without touching other packages - follow these steps:
+
+1. Add a dedicated `nixpkgs-my-package` input based on `nixpkgs-unstable`.
+2. Run `nix flake update nixpkgs-my-package`.
+3. Import your package from `inputs.nixpkgs-my-package` in the package list.
+
+For an explicit example, see this [pull request](https://github.com/stackrox/stackrox-env/pull/74).

--- a/flake.lock
+++ b/flake.lock
@@ -69,6 +69,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-golang": {
+      "locked": {
+        "lastModified": 1727266098,
+        "narHash": "sha256-AHTKbJ9ffR7Nx+XcR2XP0AYLI4OlUh2IGh4SAkdG5Ig=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4f31540079322e6013930b5b2563fd10f96917f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1714640452,
@@ -157,6 +173,7 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-golang": "nixpkgs-golang",
         "nixpkgs-terraform": "nixpkgs-terraform"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs-golang.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nixpkgs-terraform.url = "github:stackbuilders/nixpkgs-terraform";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
@@ -39,6 +40,7 @@
         let
           # Pinned packages.
           custom = import ./pkgs { inherit pkgs; };
+          golang = (import inputs.nixpkgs-golang { inherit system; }).go_1_22;
           terraform = inputs.nixpkgs-terraform.packages.${system}."1.5.7";
 
           # Add Darwin packages here.
@@ -123,7 +125,7 @@
                 prometheus
                 wget
                 ;
-              go = pkgs.go_1_22;
+              go = golang;
               helm = pkgs.kubernetes-helm;
               jsonnet = pkgs.go-jsonnet;
               python = pkgs.python3.withPackages python-pkgs;


### PR DESCRIPTION
Because we faced darwin build failures in https://github.com/stackrox/stackrox-env/pull/72, we now start by bumping only the golang package to `go 1.22.7`.